### PR TITLE
Add public constructors for objects that take IntPtr

### DIFF
--- a/src/WaylandSharpGen/Client/WlClientBuilder.cs
+++ b/src/WaylandSharpGen/Client/WlClientBuilder.cs
@@ -134,26 +134,51 @@ internal class WlClientBuilder
 
         var protocolClassConstructor =
             ConstructorDeclaration(
-                Identifier(interfaceName.Escape()))
-            .WithModifiers(
-                TokenList(
-                    Token(SyntaxKind.InternalKeyword)))
-            .WithParameterList(
-                ParameterList(
-                    SingletonSeparatedList(
-                        Parameter(
-                            Identifier("proxyObject"))
-                        .WithType(
-                            _WlProxyPointerSyntax))))
-            .WithInitializer(
-                ConstructorInitializer(
-                    SyntaxKind.BaseConstructorInitializer,
-                    ArgumentList(
+                    Identifier(interfaceName.Escape()))
+               .WithModifiers(
+                    TokenList(
+                        Token(SyntaxKind.PublicKeyword)))
+               .WithParameterList(
+                    ParameterList(
                         SingletonSeparatedList(
-                            Argument(
-                                IdentifierName("proxyObject"))))))
-            .WithBody(
-                Block());
+                            Parameter(
+                                    Identifier("proxyObject"))
+                               .WithType(
+                                    _WlIntPtrTypeSyntax))))
+               .WithInitializer(
+                    ConstructorInitializer(
+                        SyntaxKind.BaseConstructorInitializer,
+                        ArgumentList(
+                            SingletonSeparatedList(
+                                Argument(
+                                    CastExpression(_WlProxyPointerSyntax, IdentifierName("proxyObject")))))))
+               .WithBody(
+                    Block());
+
+        members.Add(protocolClassConstructor);
+
+        protocolClassConstructor =
+            ConstructorDeclaration(
+                    Identifier(interfaceName.Escape()))
+               .WithModifiers(
+                    TokenList(
+                        Token(SyntaxKind.InternalKeyword)))
+               .WithParameterList(
+                    ParameterList(
+                        SingletonSeparatedList(
+                            Parameter(
+                                    Identifier("proxyObject"))
+                               .WithType(
+                                    _WlProxyPointerSyntax))))
+               .WithInitializer(
+                    ConstructorInitializer(
+                        SyntaxKind.BaseConstructorInitializer,
+                        ArgumentList(
+                            SingletonSeparatedList(
+                                Argument(
+                                    IdentifierName("proxyObject"))))))
+               .WithBody(
+                    Block());
 
         members.Add(protocolClassConstructor);
 

--- a/src/WaylandSharpGen/Client/WlClientIdentifiers.cs
+++ b/src/WaylandSharpGen/Client/WlClientIdentifiers.cs
@@ -12,6 +12,9 @@ internal static class WlClientIdentifiers
     public static readonly IdentifierNameSyntax _WlProxyTypeSyntax = IdentifierName(_WlProxyTypeName);
     public static readonly PointerTypeSyntax _WlProxyPointerSyntax = PointerType(_WlProxyTypeSyntax);
 
+    public const string _WlIntPtrTypeName = "System.IntPtr";
+    public static readonly IdentifierNameSyntax _WlIntPtrTypeSyntax = IdentifierName(_WlIntPtrTypeName);
+
     public const string WlDisplayTypeName = "WlDisplay";
     public static readonly IdentifierNameSyntax WlDisplayTypeSyntax = IdentifierName(WlDisplayTypeName);
 


### PR DESCRIPTION
This allows integration of WaylandSharp with SDL or GLFW, as they just pass an nint/IntPtr

Closes #3 