### PR TITLE
Show relevant `.csproj` settings (it doesn't work without them)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,20 @@ dotnet add package WaylandSharp
 
 Grab `wayland.xml` from [freedesktop.org](https://gitlab.freedesktop.org/wayland/wayland/-/blob/main/protocol/wayland.xml). Drop the file into your project.
 
+Add the following to your `.csproj`:
+```xml
+<ItemGroup>
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="WaylandProtocol" />
+    <AdditionalFiles Include="wayland.xml" WaylandProtocol="client" />
+    <!-- Add additional protocol files with more AdditionalFiles tags -->
+</ItemGroup>
+```
+
 > No support for generating server-side bindings yet.
 
 Benefit! :bread:
+
+
 
 ## Quick Guide
 


### PR DESCRIPTION
I tried simply dumping `wayland.xml` into my project folder, and it did nothing. So it would probably be a good idea to mention the necessary project settings to include it.