### PR TITLE
Implement WlFixedToDouble and WlFixedFromDouble in C#

### DIFF
--- a/src/WaylandSharp.IntegrationTests/ClientTest.cs
+++ b/src/WaylandSharp.IntegrationTests/ClientTest.cs
@@ -1,0 +1,13 @@
+namespace WaylandSharp.IntegrationTests;
+
+public class ClientTest
+{
+    [Fact]
+    public void WlFixedFromDouble_WlFixedToDouble_ShouldWork()
+    {
+        var f = Client.WlFixedFromDouble(16.0);
+        var d = Client.WlFixedToDouble(f);
+
+        Assert.Equal(16.0, d);
+    }
+}

--- a/src/WaylandSharpGen/Client/WlClientPinvokeBuilder.cs
+++ b/src/WaylandSharpGen/Client/WlClientPinvokeBuilder.cs
@@ -358,11 +358,15 @@ internal static unsafe class Client
     [DllImport(LibWaylandClient, EntryPoint = "wl_proxy_create_wrapper", ExactSpelling = true)]
     public static extern void* WlProxyCreateWrapper(void* proxy);
 
-    [DllImport(LibWaylandClient, EntryPoint = "wl_fixed_to_double", ExactSpelling = true)]
-    public static extern double WlFixedToDouble(_WlFixedT f);
+    public static double WlFixedToDouble(_WlFixedT f)
+    {
+        return f.ToDouble();
+    }
 
-    [DllImport(LibWaylandClient, EntryPoint = "wl_fixed_from_double", ExactSpelling = true)]
-    public static extern _WlFixedT WlFixedFromDouble(double d);
+    public static _WlFixedT WlFixedFromDouble(double d)
+    {
+        return new _WlFixedT(d);
+    }
 }
 """;
 }

--- a/src/WaylandSharpGen/WlBindingGenerator.cs
+++ b/src/WaylandSharpGen/WlBindingGenerator.cs
@@ -284,6 +284,16 @@ internal readonly struct {{_WlFixedTTypeName}} : IEquatable<{{_WlFixedTTypeName}
 {
     private readonly uint _value;
 
+    public {{_WlFixedTTypeName}}(double d)
+    {
+        _value = (uint) (d * 256.0);
+    }
+
+    public double ToDouble()
+    {
+        return _value / 256.0;
+    }
+
     public bool Equals({{_WlFixedTTypeName}} other)
     {
         return _value == other._value;


### PR DESCRIPTION
There was a breaking change a while ago, and the corresponding wl_fixed_to_double and wl_fixed_from_double functions are no longer implemented in the libwayland-client library.

Instead, they are static functions in the header file.