### PR TITLE
allow-nulls and nullable objects

### DIFF
--- a/src/WaylandSharpGen/Client/WlClientBuilder.cs
+++ b/src/WaylandSharpGen/Client/WlClientBuilder.cs
@@ -841,7 +841,7 @@ internal class WlClientBuilder
                                 accessArgElementAt(index, "s")))))));
         }
 
-        static ExpressionSyntax convertObject(int index, string? interfaceName)
+        static ExpressionSyntax convertObject(int index, string? interfaceName, bool isNullable)
         {
             if (interfaceName == null)
             {
@@ -850,7 +850,7 @@ internal class WlClientBuilder
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             WlClientObjectTypeSyntax,
-                            IdentifierName("GetObject")))
+                            IdentifierName(isNullable ? "GetNullableObject" : "GetObject")))
                     .WithArgumentList(
                         ArgumentList(
                             SingletonSeparatedList(
@@ -866,7 +866,7 @@ internal class WlClientBuilder
                         SyntaxKind.SimpleMemberAccessExpression,
                         WlClientObjectTypeSyntax,
                         GenericName(
-                            Identifier("GetObject"))
+                            Identifier(isNullable ? "GetNullableObject" : "GetObject"))
                         .WithTypeArgumentList(
                             TypeArgumentList(
                                 SingletonSeparatedList<TypeSyntax>(
@@ -934,7 +934,7 @@ internal class WlClientBuilder
             ArgumentType.Uint => accessArgElementAt(argIndex, "u"),
             ArgumentType.Fixed => convertWlFixed(argIndex),
             ArgumentType.String => convertCharPointer(argIndex),
-            ArgumentType.Object => convertObject(argIndex, argDefinition.Interface),
+            ArgumentType.Object => convertObject(argIndex, argDefinition.Interface, argDefinition.Nullable),
             ArgumentType.NewId => convertNewId(argIndex, argDefinition.Interface),
             ArgumentType.Array => convertArray(argIndex),
             ArgumentType.FD => accessArgElementAt(argIndex, "h"),
@@ -1117,6 +1117,13 @@ public abstract unsafe class {{WlClientObjectTypeName}} : IEquatable<{{WlClientO
 
     internal static T GetObject<T>({{_WlProxyTypeName}}* proxyObject) where T : {{WlClientObjectTypeName}}
     {
+        return (T)GetObject(proxyObject);
+    }
+
+    internal static T? GetNullableObject<T>({{_WlProxyTypeName}}* proxyObject) where T : {{WlClientObjectTypeName}}
+    {
+        if (proxyObject == null) return null;
+
         return (T)GetObject(proxyObject);
     }
 

--- a/src/WaylandSharpGen/Xml/MethodArgument.cs
+++ b/src/WaylandSharpGen/Xml/MethodArgument.cs
@@ -36,7 +36,7 @@ internal sealed record MethodArgument
             "fd" => ArgumentType.FD,
             _ => throw new InvalidOperationException($"Invalid message argument type: {element.GetAttribute("type")}")
         };
-        var nullable = element.GetAttribute("nullable") == "true";
+        var nullable = element.GetAttribute("nullable") == "true" || element.GetAttribute("allow-null") == "true";
         var interfaceName = element.GetAttribute("interface").DefiniteNull();
         var documentation = element.GetAttribute("summary").DefiniteNull();
         var enumName = element.GetAttribute("enum").DefiniteNull();


### PR DESCRIPTION
Hi, 

This change makes a few small tweaks to get nullable object arguments generally working, in pursuit of engaging with the `wlr_data_control_unstable_v1` protocol.

- the latter protocol uses an `allow-null` attribute as its nullability flag - the Xml reader has been extended to match this as well as the original `nullable`
- a new `WlClientObject.GetNullableObject` helper has been added, which does the same as `GetObject`, except it also checks for an incoming null pointer, and returns `T?`
- `convertObject` has been updated to prefer `GetNullableObject` when the method arg is marked as nullable

These all add up to a working prototype for my purposes. I notice the test suite isn't in a working state currently and so have opportunistically avoided adding any tests. If this is a blocker to getting these changes merged, I'd be very happy to revisit (and maybe existing broken tests can be fixed up)

Thanks a lot for this very helpful library - even though it's not complete I've found it very useful.
